### PR TITLE
Improve source name

### DIFF
--- a/lib/jaspohrchevrolet.rb
+++ b/lib/jaspohrchevrolet.rb
@@ -5,17 +5,19 @@ require 'f1sales_custom/hooks'
 
 module Jaspohrchevrolet
   class Error < StandardError; end
+
   class F1SalesCustom::Hooks::Lead
     def self.switch_source(lead)
-      source_name = lead.source.name ? lead.source.name : ''
-      message = lead.message ? lead.message : ''
-      product_name = lead.product.name ? lead.product.name : ''
+      source_name = lead.source.name || ''
+      lead_message = lead.message || ''
+      product_name = lead.product.name || ''
 
       if source_name.downcase.include?('global connect')
-        "GC#{source_name.delete_prefix('Global Connect')} - #{lead.message} - #{product_name}"
-      else
-        source_name
+        source_name = "GC#{source_name.delete_prefix('Global Connect')}"
+        source_name += " - #{lead_message}" unless lead_message.empty?
+        source_name += " - #{product_name}" unless product_name.empty?
       end
+      source_name
     end
   end
 end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 
 RSpec.describe F1SalesCustom::Hooks::Lead do
-  context "when product is from API" do
+  context "when product is from Global Connect" do
     let(:lead) do
       lead = OpenStruct.new
       lead.source = source
@@ -28,6 +28,20 @@ RSpec.describe F1SalesCustom::Hooks::Lead do
     context 'when product come from Global Connect' do
       it 'when message contains REDE DIGITAL - SEMINOVOS' do
         expect(described_class.switch_source(lead)).to eq('GC - Santa Cruz - REDE DIGITAL - SEMINOVOS - Tracker')
+      end
+    end
+
+    context 'when message is empty and product is not' do
+      before { lead.message = nil }
+      it 'when message contains REDE DIGITAL - SEMINOVOS' do
+        expect(described_class.switch_source(lead)).to eq('GC - Santa Cruz - Tracker')
+      end
+    end
+
+    context 'when product is empty and message is not' do
+      before { lead.product.name = nil }
+      it 'when message contains REDE DIGITAL - SEMINOVOS' do
+        expect(described_class.switch_source(lead)).to eq('GC - Santa Cruz - REDE DIGITAL - SEMINOVOS')
       end
     end
 


### PR DESCRIPTION
This improvement is to make the font more elegant, not showing `Source - - product` or `Source - message - `